### PR TITLE
Multiple networks support and a few readability tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+config.log
+config.status
+configure

--- a/bin/kvm-maas-add-node
+++ b/bin/kvm-maas-add-node
@@ -5,13 +5,14 @@ THISDIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)"
 source $THISDIR/../libexec/kvm-maas/common.sh
 
 if [ $# -lt 3 ]; then
-    echo "usage: $progname <NODE-NAME> <VIRT-NETWORK-NAME> <MAAS-PROFILE-NAME>"
+    echo "usage: $progname <NODE-NAME> <MAAS-PROFILE-NAME> <PXE-VIRT-NETWORK-NAME-1> [<EXTRA-VIRT-NETWORK-NAME-2>...]"
     exit 1
 fi
 
 export NODE=$1
-export NETWORK=$2
-export MAAS_PROFILE=$3
+export MAAS_PROFILE=$2
+shift 2
+export NETWORKS="$@"
 
 # This is a sanity check on connecting to the MAAS profile.
 maas $MAAS_PROFILE version read >/dev/null 2>&1 || die "MAAS verification failed using profile '$MAAS_PROFILE'"
@@ -21,9 +22,12 @@ RUN() {
     $THISDIR/../libexec/kvm-maas/$2 || die "failed to run $2"
 }
 
-if ! virt_network_exists "$NETWORK"; then
-    die "$NETWORK: unknown virsh network"
-fi
+networks_args=""
+for net in ${NETWORKS[@]}; do
+    if ! virt_network_exists "$net"; then
+        die "$net: unknown virsh network"
+    fi
+done
 
 if virt_domain_exists $NODE; then
     die "domain $NODE already exists"

--- a/bin/kvm-maas-remove-node
+++ b/bin/kvm-maas-remove-node
@@ -8,22 +8,25 @@ type -p xmlstarlet > /dev/null || die "please install xmlstarlet(1)"
 type -p python2 > /dev/null || die "please install python2(1)"
 
 if [ $# -lt 3 ]; then
-    echo "usage: $progname <NODE-NAME> <VIRT-NETWORK-NAME> <MAAS-PROFILE-NAME>"
+    echo "usage: $progname <NODE-NAME> <MAAS-PROFILE-NAME> <PXE-VIRT-NETWORK-NAME-1> [<EXTRA-NETWORK-NAME-2>...]"
     exit 1
 fi
 
 export NODE=$1
-export NETWORK=$2
-export MAAS_PROFILE=$3
+export MAAS_PROFILE=$2
+shift 2
+export NETWORKS="$@"
 
 RUN() {
     echo "$1"
     $THISDIR/../libexec/kvm-maas/$2 || die "failed to run $2"
 }
 
-if ! virt_network_exists "$NETWORK"; then
-    die "$NETWORK: unknown virsh network"
-fi
+for net in ${NETWORKS[@]}; do
+    if ! virt_network_exists "$net"; then
+        die "$net: unknown virsh network"
+    fi
+done
 
 set -e
 

--- a/bin/kvm-maas-remove-node
+++ b/bin/kvm-maas-remove-node
@@ -7,26 +7,18 @@ source $THISDIR/../libexec/kvm-maas/common.sh
 type -p xmlstarlet > /dev/null || die "please install xmlstarlet(1)"
 type -p python2 > /dev/null || die "please install python2(1)"
 
-if [ $# -lt 3 ]; then
-    echo "usage: $progname <NODE-NAME> <MAAS-PROFILE-NAME> <PXE-VIRT-NETWORK-NAME-1> [<EXTRA-NETWORK-NAME-2>...]"
+if [ $# -lt 2 ]; then
+    echo "usage: $progname <NODE-NAME> <MAAS-PROFILE-NAME>"
     exit 1
 fi
 
 export NODE=$1
 export MAAS_PROFILE=$2
-shift 2
-export NETWORKS="$@"
 
 RUN() {
     echo "$1"
     $THISDIR/../libexec/kvm-maas/$2 || die "failed to run $2"
 }
-
-for net in ${NETWORKS[@]}; do
-    if ! virt_network_exists "$net"; then
-        die "$net: unknown virsh network"
-    fi
-done
 
 set -e
 

--- a/libexec/kvm-maas/node-accept
+++ b/libexec/kvm-maas/node-accept
@@ -12,10 +12,10 @@ fi
 
 set +e
 
-pxe_network_addr=$(virt_network_address $NETWORKS[0])
+pxe_network_addr=$(virt_network_address ${NETWORKS[0]})
 
 if [ -z "$pxe_network_addr" ]; then
-    die "could not determine IP address for PXE network $NETWORKS[0]'"
+    die "could not determine IP address for PXE network ${NETWORKS[0]}'"
 fi
 
 system_id=$(maas_system_id $MAAS_PROFILE $(virt_domain_ip_address $NODE))

--- a/libexec/kvm-maas/node-accept
+++ b/libexec/kvm-maas/node-accept
@@ -15,7 +15,7 @@ set +e
 pxe_network_addr=$(virt_network_address ${NETWORKS[0]})
 
 if [ -z "$pxe_network_addr" ]; then
-    die "could not determine IP address for PXE network ${NETWORKS[0]}'"
+    die "could not determine IP address for PXE network '${NETWORKS[0]}'"
 fi
 
 system_id=$(maas_system_id $MAAS_PROFILE $(virt_domain_ip_address $NODE))

--- a/libexec/kvm-maas/node-accept
+++ b/libexec/kvm-maas/node-accept
@@ -12,10 +12,10 @@ fi
 
 set +e
 
-network_addr=$(virt_network_address $NETWORK)
+pxe_network_addr=$(virt_network_address $NETWORKS[0])
 
-if [ -z "$network_addr" ]; then
-    die "could not determine IP address for $NETWORK'"
+if [ -z "$pxe_network_addr" ]; then
+    die "could not determine IP address for PXE network $NETWORKS[0]'"
 fi
 
 system_id=$(maas_system_id $MAAS_PROFILE $(virt_domain_ip_address $NODE))
@@ -38,7 +38,7 @@ fi
 
 maas $MAAS_PROFILE $power update $system_id \
      power_type=virsh \
-     power_parameters_power_address=qemu+ssh://$USER@$network_addr/system \
+     power_parameters_power_address=qemu+ssh://$USER@$pxe_network_addr/system \
      power_parameters_power_id=$NODE \
      hostname=$NODE
 

--- a/libexec/kvm-maas/virt-img-cleanup
+++ b/libexec/kvm-maas/virt-img-cleanup
@@ -12,9 +12,12 @@ if virt_domain_exists $NODE; then
     virsh undefine $NODE
 fi
 
-vol_path=$(virt_domain_volume_path $VIRT_POOL $NODE)
+vol_with_type="${NODE}.${VIRT_IMAGE_TYPE}"
+vol_path=$(virt_domain_volume_path $VIRT_POOL $vol_with_type)
 
 if [ -n "$vol_path" ]; then
     virsh pool-refresh default
-    virsh vol-delete --pool $VIRT_POOL $NODE
+    virsh vol-delete --pool $VIRT_POOL $vol_with_type
+else
+    echo "No image $vol_with_type to clean."
 fi

--- a/libexec/kvm-maas/virt-node-define
+++ b/libexec/kvm-maas/virt-node-define
@@ -8,6 +8,11 @@ if virt_domain_exists $NODE; then
     die "domain $NODE already exists"
 fi
 
+networks_args=""
+for net in ${NETWORKS[@]}; do
+    networks_args="--network=network=$net,model=virtio $networks_args"
+done
+
 virt-install \
     --name=$NODE \
     --connect=${QEMU_URI} \
@@ -22,8 +27,5 @@ virt-install \
     --os-variant=generic \
     --accelerate \
     --disk=$VIRT_IMAGE_DIR/${NODE}.${VIRT_IMAGE_TYPE},bus=virtio,format=${VIRT_IMAGE_TYPE},cache=writeback,sparse=true,size=${VIRT_DISK_SIZE} \
-    --network=network=$NETWORK,model=virtio \
-    --network=network=${NETWORK2:-$NETWORK},model=virtio \
-    --network=network=${NETWORK3:-$NETWORK},model=virtio \
-    --network=network=${NETWORK4:-$NETWORK},model=virtio \
+    $networks_args
 


### PR DESCRIPTION
Order of arguments to kvm-maas-add-node has been altered to put
networks (one or more) at the end. For kvm-maas-remove-node, a
list of networks is accepted for compatibility, but it's ignored.
